### PR TITLE
Add mood selection feature

### DIFF
--- a/src/HabitTracker.tsx
+++ b/src/HabitTracker.tsx
@@ -10,12 +10,22 @@ interface DayRecord {
   date: string;
   completedHabits: string[];
   highlight?: string;
+  moods?: Record<string, string>;
 }
 
 // Keys for localStorage
 const STORAGE_KEYS = {
   HABITS: 'habit-tracker-habits',
   RECORDS: 'habit-tracker-records',
+};
+
+const MOOD_OPTIONS = ['😀', '😐', '😞'];
+
+const chooseMood = () => {
+  const promptText = `Выберите настроение:\n1 - ${MOOD_OPTIONS[0]}\n2 - ${MOOD_OPTIONS[1]}\n3 - ${MOOD_OPTIONS[2]}`;
+  const choice = window.prompt(promptText);
+  const index = choice ? Number(choice) - 1 : -1;
+  return MOOD_OPTIONS[index];
 };
 
 function HabitTracker() {
@@ -60,16 +70,32 @@ function HabitTracker() {
     setRecords(prev => {
       const existingRecord = prev.find(r => r.date === dateStr);
       if (existingRecord) {
-        const newCompletedHabits = existingRecord.completedHabits.includes(habitId)
+        const isCompleted = existingRecord.completedHabits.includes(habitId);
+        const newCompletedHabits = isCompleted
           ? existingRecord.completedHabits.filter(id => id !== habitId)
           : [...existingRecord.completedHabits, habitId];
+        const newMoods = { ...(existingRecord.moods || {}) };
+        if (isCompleted) {
+          delete newMoods[habitId];
+        } else {
+          const mood = chooseMood();
+          if (mood) newMoods[habitId] = mood;
+        }
         return prev.map(r =>
           r.date === dateStr
-            ? { ...r, completedHabits: newCompletedHabits }
+            ? { ...r, completedHabits: newCompletedHabits, moods: newMoods }
             : r
         );
       }
-      return [...prev, { date: dateStr, completedHabits: [habitId] }];
+      const mood = chooseMood();
+      return [
+        ...prev,
+        {
+          date: dateStr,
+          completedHabits: [habitId],
+          moods: mood ? { [habitId]: mood } : {},
+        },
+      ];
     });
   };
 
@@ -83,10 +109,17 @@ function HabitTracker() {
   const removeHabit = (habitId: string) => {
     setHabits(prev => prev.filter(h => h.id !== habitId));
     // Clean up records for the removed habit
-    setRecords(prev => prev.map(record => ({
-      ...record,
-      completedHabits: record.completedHabits.filter(id => id !== habitId)
-    })));
+    setRecords(prev => prev.map(record => {
+      const { moods, ...rest } = record;
+      const newMoods = Object.fromEntries(
+        Object.entries(moods || {}).filter(([id]) => id !== habitId)
+      );
+      return {
+        ...rest,
+        completedHabits: record.completedHabits.filter(id => id !== habitId),
+        moods: Object.keys(newMoods).length ? newMoods : undefined,
+      };
+    }));
   };
 
   const updateHighlight = (day: number, highlight: string) => {
@@ -177,16 +210,21 @@ function HabitTracker() {
                   <td className="px-4 py-2 border-b text-center font-medium">{day}</td>
                   {habits.map(habit => (
                     <td key={habit.id} className="px-4 py-2 border-b text-center">
-                      <button
-                        onClick={() => toggleHabit(habit.id, day)}
-                        className={`w-6 h-6 rounded ${
-                          getRecord(day)?.completedHabits.includes(habit.id)
-                            ? 'text-green-500 hover:text-green-700'
-                            : 'text-gray-300 hover:text-gray-400'
-                        }`}
-                      >
-                        <CheckSquare className="w-full h-full" />
-                      </button>
+                      <div className="flex items-center justify-center gap-1">
+                        <button
+                          onClick={() => toggleHabit(habit.id, day)}
+                          className={`w-6 h-6 rounded ${
+                            getRecord(day)?.completedHabits.includes(habit.id)
+                              ? 'text-green-500 hover:text-green-700'
+                              : 'text-gray-300 hover:text-gray-400'
+                          }`}
+                        >
+                          <CheckSquare className="w-full h-full" />
+                        </button>
+                        {getRecord(day)?.moods?.[habit.id] && (
+                          <span>{getRecord(day)?.moods?.[habit.id]}</span>
+                        )}
+                      </div>
                     </td>
                   ))}
                   <td className="px-4 py-2 border-b">


### PR DESCRIPTION
## Summary
- allow the user to choose a mood when checking a habit
- store mood in day records and clean up moods when a habit is removed
- display the recorded mood next to the completed habit

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68433f569fac83248a4325f9ad1e01f3