### PR TITLE
Add mood options and update DayRecord

### DIFF
--- a/src/HabitTracker.tsx
+++ b/src/HabitTracker.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Calendar, CheckSquare, Plus, X } from 'lucide-react';
 import MoodModal from './MoodModal';
 
+const MOOD_OPTIONS = ['😀', '😐', '😢', '😡'];
+
 interface Habit {
   id: string;
   name: string;
@@ -11,6 +13,7 @@ interface DayRecord {
   date: string;
   completedHabits: string[];
   highlight?: string;
+  moods?: Record<string, string>;
 }
 
 // Keys for localStorage


### PR DESCRIPTION
## Summary
- add `MOOD_OPTIONS` array for mood selection
- extend `DayRecord` with optional `moods`
- ensure mood data persists when toggling or applying

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68434801f2c48324ae87f334fb56c8df